### PR TITLE
Add RLS policies, storage policies, seed data, and dashboard stats RPC

### DIFF
--- a/admin/lib/queries/stats.ts
+++ b/admin/lib/queries/stats.ts
@@ -1,16 +1,18 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-// Home dashboard stats — one function per stat card.
+// Home dashboard stats.
 // Owner: Database + API. Consumer: UI (Home page).
 //
-// Each card needs: total count, the most recent updated_at, and how many
-// rows were updated/created in the last 7 days. Events additionally needs
-// an "upcoming" count (is_published and event_date >= today).
+// All four cards are served by a single `get_dashboard_stats()` RPC
+// (supabase/migrations/0006_dashboard_stats.sql) rather than by counting from
+// the client: each card needs a total, a 7-day count and a last-updated
+// timestamp, which as separate supabase-js calls is 13 round trips to render
+// one page.
 //
-// Implement using supabase-js `.select('*', { count: 'exact', head: true })`
-// for counts, `.order('updated_at', { ascending: false }).limit(1)` for the
-// most recent timestamp, and `.gte('updated_at', <7 days ago ISO string>)`
-// for the recent-activity count. See docs/SCHEMA.md for table/column names.
+// The RPC is SECURITY INVOKER, so the RLS policies from 0003 apply to it the
+// same way they apply to a plain select — a signed-in admin gets counts across
+// all rows, anyone else gets published rows only. Nothing here re-checks
+// permissions, because nothing here should.
 
 export interface CardStats {
   total: number;
@@ -22,26 +24,53 @@ export interface EventStats extends CardStats {
   upcoming: number;
 }
 
+export interface DashboardStats {
+  teamMembers: CardStats;
+  events: EventStats;
+  startups: CardStats;
+  media: CardStats;
+}
+
+/**
+ * Every dashboard stat in one round trip. Prefer this on the Home page.
+ */
+export async function getDashboardStats(
+  supabase: SupabaseClient,
+): Promise<DashboardStats> {
+  const { data, error } = await supabase.rpc("get_dashboard_stats");
+
+  if (error) throw error;
+  if (!data) throw new Error("get_dashboard_stats returned no data");
+
+  // The RPC builds this object with json_build_object, so its shape is fixed by
+  // the migration rather than inferable from the generated Supabase types.
+  return data as DashboardStats;
+}
+
+// Per-card accessors, kept for the original call signatures. Each one is a
+// full round trip, so calling all four to render the dashboard defeats the
+// point — use getDashboardStats() and destructure it instead.
+
 export async function getTeamMemberStats(
   supabase: SupabaseClient,
 ): Promise<CardStats> {
-  throw new Error("TODO: implement (see comment above)");
+  return (await getDashboardStats(supabase)).teamMembers;
 }
 
 export async function getEventStats(
   supabase: SupabaseClient,
 ): Promise<EventStats> {
-  throw new Error("TODO: implement (see comment above)");
+  return (await getDashboardStats(supabase)).events;
 }
 
 export async function getStartupStats(
   supabase: SupabaseClient,
 ): Promise<CardStats> {
-  throw new Error("TODO: implement (see comment above)");
+  return (await getDashboardStats(supabase)).startups;
 }
 
 export async function getMediaStats(
   supabase: SupabaseClient,
 ): Promise<CardStats> {
-  throw new Error("TODO: implement (see comment above)");
+  return (await getDashboardStats(supabase)).media;
 }

--- a/admin/lib/types.ts
+++ b/admin/lib/types.ts
@@ -65,7 +65,9 @@ export type MediaAttachedToType = "team_member" | "event" | "startup";
 
 export interface Media {
   id: string;
-  storage_path: string;
+  /** NULL for rows seeded from the repo's images/ directory — those files are
+   *  not in a Storage bucket. Set on upload via the Media Manager. */
+  storage_path: string | null;
   url: string;
   alt_text: string | null;
   caption: string | null;

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -1,8 +1,9 @@
 # Database Schema Reference
 
-Source of truth: [`supabase/migrations/0001_init_schema.sql`](../supabase/migrations/0001_init_schema.sql)
-and [`0002_storage_buckets.sql`](../supabase/migrations/0002_storage_buckets.sql).
-TypeScript mirror: [`admin/lib/types.ts`](../admin/lib/types.ts).
+Source of truth: everything in [`supabase/migrations/`](../supabase/migrations),
+applied in order — `0001` tables/triggers/`is_admin()`, `0002` Storage buckets,
+`0003` RLS policies, `0004` Storage policies, `0005` seed data, `0006` dashboard
+stats RPC. TypeScript mirror: [`admin/lib/types.ts`](../admin/lib/types.ts).
 
 If you change a column, update the migration, `lib/types.ts`, and this table
 in the same PR — the public site and the admin panel both depend on these
@@ -24,12 +25,15 @@ names matching exactly.
 checks whether `auth.uid()` exists in `admin_users`. There is no other gate —
 whoever has a row in `admin_users` can write to every content table.
 
-## Row Level Security spec
+## Row Level Security
 
-**Owner: Database + API.** The migration (`0001_init_schema.sql`) enables RLS
-on every table but deliberately leaves the `create policy` statements as a
-`TODO` — writing them is real backend work, not boilerplate. This is the spec
-to implement against:
+**Owner: Database + API.** `0001_init_schema.sql` enables RLS on every table
+and ships no policies; the policies live in
+[`0003_rls_policies.sql`](../supabase/migrations/0003_rls_policies.sql) (content
+tables) and [`0004_storage_policies.sql`](../supabase/migrations/0004_storage_policies.sql)
+(Storage). `0001` is applied and frozen — don't move them back into it.
+
+This is what is enforced:
 
 | Table | `select` | `insert` / `update` / `delete` |
 |---|---|---|
@@ -41,19 +45,28 @@ to implement against:
 | `admin_users` | `using (is_admin())` | **no policy at all** — writes only via `service_role`, bypassing RLS entirely |
 | `activity_logs` | `using (is_admin())` | **no policy at all** — writes only via `service_role` |
 
-For `insert`, the check goes in `with check (...)` instead of `using (...)`;
-for `update`, both are needed (`using` gates which existing rows you can
-touch, `with check` gates what you can change them to). `is_admin()` is
-already defined in the migration — call it, don't reimplement the
-`admin_users` lookup inline.
+Reads are scoped `to anon, authenticated` and writes `to authenticated`. A
+policy with no role list applies to `PUBLIC` — every role — which is how the
+database briefly ended up with no access control at all; state the roles.
 
-The same pattern applies to the 4 Storage buckets in
-`0002_storage_buckets.sql` (policies on `storage.objects`, scoped by
-`bucket_id`) — see the `TODO` comment in that file.
+`is_admin()` is defined in `0001` as `security definer`, which is what lets the
+policy on `admin_users` query `admin_users` without recursing. Call it, don't
+reimplement the lookup inline. It is wrapped as `(select is_admin())` so
+Postgres evaluates it once per statement instead of once per row.
 
-Before merging, verify both directions for at least one table: a real anon
-(logged-out) request gets the expected rows and nothing more, and a real
-signed-in admin request can write.
+**On `anon` having table grants:** this project uses Supabase's default
+privileges, so `anon` and `authenticated` hold `select`/`insert`/`update`/
+`delete` on every table in `public` automatically, including tables added
+later. RLS is therefore the *only* thing gating access — there is nothing to
+"also" lock down, and a permissive policy is immediately exploitable.
+`admin_users` and `activity_logs` are the exception: `0003` revokes those
+grants outright as a second layer, since nothing should ever write to them
+from the client. `TRUNCATE` is also revoked on the content tables, because RLS
+does not apply to `TRUNCATE`.
+
+Before merging a policy change, verify both directions for at least one table:
+a real anon (logged-out) request gets the expected rows and nothing more, and a
+real signed-in admin request can write.
 
 ## Storage buckets
 
@@ -64,7 +77,36 @@ signed-in admin request can write.
 | `startup-images` | `startups.image_url` |
 | `media-gallery` | standalone Media Manager uploads |
 
-All buckets are public-read, admin-write (same `is_admin()` check).
+All buckets are public-read, admin-write (same `is_admin()` check) — 16
+policies on `storage.objects` in `0004`, four per bucket, each scoped by
+`bucket_id`.
+
+Because the buckets are `public = true`, the CDN route
+(`/storage/v1/object/public/<bucket>/<path>`) serves objects without consulting
+RLS at all. The `select` policies govern the authenticated API route. Reads are
+public either way — these are website images — so don't read the `select`
+policy as though it hides something.
+
+## Seed data
+
+[`0005_seed_initial_content.sql`](../supabase/migrations/0005_seed_initial_content.sql)
+loads the site's committed JSON: `team.json` → 4 departments + 5 members,
+`startups.json` → 6 startups, `data/media.json` → 21 media rows. Image paths
+stay as `images/...` (served from GitHub Pages); nothing is in Storage yet, so
+those `media` rows carry `storage_path = NULL`. Every insert is
+`on conflict … do nothing`, so re-running it is a no-op.
+
+Two field renames to watch, since the JSON and the schema disagree:
+`startups.json` `test_url`/`test_text` map to `demo_url`/`demo_text`, and its
+`id` becomes a lowercased `slug`.
+
+## Dashboard stats
+
+[`0006_dashboard_stats.sql`](../supabase/migrations/0006_dashboard_stats.sql)
+defines `get_dashboard_stats()`, one RPC returning every Home-page card stat as
+JSON. It is `security invoker`, so RLS applies to it normally — admins get
+counts over all rows, anyone else over published rows only. Consumed by
+[`admin/lib/queries/stats.ts`](../admin/lib/queries/stats.ts).
 
 ## Applying migrations
 
@@ -74,11 +116,11 @@ npx supabase link --project-ref <ref>   # from the Supabase dashboard URL
 npx supabase db push               # applies supabase/migrations/*.sql in order
 ```
 
-Fill in the RLS policy `TODO`s in `0001_init_schema.sql` and
-`0002_storage_buckets.sql` (see the spec above) before the first `db push` —
-until then, RLS is enabled with no policies, which means every table is
-fully locked down to both anon and authenticated requests.
+New migrations: add a new numbered file to `supabase/migrations/` — never edit
+one that has already been applied to the live project — then `db push` again.
 
-New migrations after that: add a new numbered file to `supabase/migrations/`
-(don't edit `0001`/`0002` again once they've been applied to the live
-project — add `0003_...sql` instead), then `supabase db push` again.
+Never create tables or policies by hand in the dashboard SQL editor. `0001` and
+`0002` were originally applied that way, which left the live database holding
+access rules that existed in no file and that git could not show. Recovering
+from it took `supabase migration repair --status applied 0001 0002` plus a
+column-by-column audit against the migration.

--- a/supabase/migrations/0003_rls_policies.sql
+++ b/supabase/migrations/0003_rls_policies.sql
@@ -1,0 +1,235 @@
+-- Row Level Security policies for the 7 content tables.
+-- Owner: Database + API. Spec: docs/SCHEMA.md ("Row Level Security spec").
+--
+-- Why this is a new migration rather than an edit to 0001:
+-- 0001 created the tables with RLS enabled and no policies, and it has already
+-- been applied to the live project. CONTRIBUTING.md forbids editing an applied
+-- migration, so the policies land here. 0001 stays frozen; its RLS TODO comment
+-- is answered by this file.
+--
+-- This migration also drops a set of permissive policies that were created by
+-- hand in the Supabase SQL editor and exist in no migration. Every one of them
+-- was `for all to public using (true) with check (true)` -- RLS switched on but
+-- enforcing nothing, which allowed any anon caller to insert themselves into
+-- admin_users and thereby gain write access to every content table.
+--
+-- Access model:
+--   team_departments  select: everyone                     write: is_admin()
+--   media             select: everyone                     write: is_admin()
+--   team_members      select: is_published or is_admin()   write: is_admin()
+--   events            select: is_published or is_admin()   write: is_admin()
+--   startups          select: is_published or is_admin()   write: is_admin()
+--   admin_users       select: is_admin()                   write: none -- service_role only
+--   activity_logs     select: is_admin()                   write: none -- service_role only
+--
+-- On this project anon and authenticated already hold table-level grants via
+-- Supabase's default privileges, so RLS is the only thing gating access. There
+-- is deliberately no `grant` statement below for the content tables.
+--
+-- is_admin() is defined in 0001 as `security definer`, which is what lets the
+-- policy on admin_users query admin_users without recursing. Call it; never
+-- reimplement the lookup inline.
+--
+-- It is wrapped as `(select is_admin())` throughout so Postgres evaluates it
+-- once per statement as an InitPlan rather than once per row.
+
+-- ---------------------------------------------------------------------------
+-- 1. Drop the hand-created permissive policies
+-- ---------------------------------------------------------------------------
+-- `if exists` so this migration also applies cleanly to a fresh database
+-- (local `supabase start`, a preview branch) where these never existed.
+
+drop policy if exists "Enable full access for team_departments" on team_departments;
+drop policy if exists "Public team_departments read"            on team_departments;
+drop policy if exists "Enable full access for team_members"     on team_members;
+drop policy if exists "Public team_members read"                on team_members;
+drop policy if exists "Enable full access for events"           on events;
+drop policy if exists "Public events read"                      on events;
+drop policy if exists "Enable full access for startups"         on startups;
+drop policy if exists "Public startups read"                    on startups;
+drop policy if exists "Enable full access for media"            on media;
+drop policy if exists "Public media read"                       on media;
+drop policy if exists "Enable full access for admin_users"      on admin_users;
+drop policy if exists "Enable full access for activity_logs"    on activity_logs;
+
+-- ---------------------------------------------------------------------------
+-- 2. Schema fixes
+-- ---------------------------------------------------------------------------
+-- The 21 rows seeded from data/media.json are files that live in the repo under
+-- images/, not objects in a Storage bucket. NULL storage_path is how a row says
+-- "legacy file, not in Storage"; the Media Manager sets it on real uploads.
+alter table media alter column storage_path drop not null;
+
+-- Natural keys so the seed in 0005 can use `on conflict ... do nothing` and be
+-- safely re-run. team_departments.slug and startups.slug are already unique
+-- from 0001; these two tables had nothing to key on.
+-- `nulls not distinct` matters: department_id is nullable, and without it two
+-- members with the same name and no department would both be allowed in.
+create unique index if not exists team_members_department_id_name_key
+  on team_members (department_id, name) nulls not distinct;
+
+create unique index if not exists media_url_key
+  on media (url);
+
+-- ---------------------------------------------------------------------------
+-- 3. team_departments -- public read, admin write
+-- ---------------------------------------------------------------------------
+create policy team_departments_select_all
+  on team_departments for select
+  to anon, authenticated
+  using (true);
+
+create policy team_departments_insert_admin
+  on team_departments for insert
+  to authenticated
+  with check ((select is_admin()));
+
+create policy team_departments_update_admin
+  on team_departments for update
+  to authenticated
+  using ((select is_admin()))
+  with check ((select is_admin()));
+
+create policy team_departments_delete_admin
+  on team_departments for delete
+  to authenticated
+  using ((select is_admin()));
+
+-- ---------------------------------------------------------------------------
+-- 4. team_members -- published rows public, everything visible to admins
+-- ---------------------------------------------------------------------------
+create policy team_members_select_published
+  on team_members for select
+  to anon, authenticated
+  using (is_published or (select is_admin()));
+
+create policy team_members_insert_admin
+  on team_members for insert
+  to authenticated
+  with check ((select is_admin()));
+
+create policy team_members_update_admin
+  on team_members for update
+  to authenticated
+  using ((select is_admin()))
+  with check ((select is_admin()));
+
+create policy team_members_delete_admin
+  on team_members for delete
+  to authenticated
+  using ((select is_admin()));
+
+-- ---------------------------------------------------------------------------
+-- 5. events
+-- ---------------------------------------------------------------------------
+create policy events_select_published
+  on events for select
+  to anon, authenticated
+  using (is_published or (select is_admin()));
+
+create policy events_insert_admin
+  on events for insert
+  to authenticated
+  with check ((select is_admin()));
+
+create policy events_update_admin
+  on events for update
+  to authenticated
+  using ((select is_admin()))
+  with check ((select is_admin()));
+
+create policy events_delete_admin
+  on events for delete
+  to authenticated
+  using ((select is_admin()));
+
+-- ---------------------------------------------------------------------------
+-- 6. startups
+-- ---------------------------------------------------------------------------
+create policy startups_select_published
+  on startups for select
+  to anon, authenticated
+  using (is_published or (select is_admin()));
+
+create policy startups_insert_admin
+  on startups for insert
+  to authenticated
+  with check ((select is_admin()));
+
+create policy startups_update_admin
+  on startups for update
+  to authenticated
+  using ((select is_admin()))
+  with check ((select is_admin()));
+
+create policy startups_delete_admin
+  on startups for delete
+  to authenticated
+  using ((select is_admin()));
+
+-- ---------------------------------------------------------------------------
+-- 7. media -- public read (it only ever holds already-public images)
+-- ---------------------------------------------------------------------------
+create policy media_select_all
+  on media for select
+  to anon, authenticated
+  using (true);
+
+create policy media_insert_admin
+  on media for insert
+  to authenticated
+  with check ((select is_admin()));
+
+create policy media_update_admin
+  on media for update
+  to authenticated
+  using ((select is_admin()))
+  with check ((select is_admin()));
+
+create policy media_delete_admin
+  on media for delete
+  to authenticated
+  using ((select is_admin()));
+
+-- ---------------------------------------------------------------------------
+-- 8. admin_users -- readable by admins, writable by nobody
+-- ---------------------------------------------------------------------------
+-- Deliberately no insert/update/delete policy. RLS is default-deny, so the
+-- absence of a policy is what makes this table service_role-only: adding an
+-- admin goes through the Next.js Route Handler using SUPABASE_SERVICE_ROLE_KEY,
+-- which bypasses RLS. A write policy here would let an admin promote anyone,
+-- and a permissive one would let anyone promote themselves.
+create policy admin_users_select_admin
+  on admin_users for select
+  to authenticated
+  using ((select is_admin()));
+
+-- ---------------------------------------------------------------------------
+-- 9. activity_logs -- readable by admins, writable by nobody
+-- ---------------------------------------------------------------------------
+-- Same reasoning. If audit logging is wired up later, write it as a
+-- `security definer` trigger on the content tables rather than adding an
+-- insert policy -- an audit trail the audited party can write to is not one.
+create policy activity_logs_select_admin
+  on activity_logs for select
+  to authenticated
+  using ((select is_admin()));
+
+-- ---------------------------------------------------------------------------
+-- 10. Grant hardening
+-- ---------------------------------------------------------------------------
+-- Defense in depth for the two service_role-only tables. The policies above
+-- already block these operations; revoking the grants means a future
+-- accidentally-permissive policy on either table still cannot be exploited.
+-- authenticated keeps select (gated to is_admin() above) so the Settings page
+-- can list admins.
+revoke all on table admin_users   from anon;
+revoke all on table activity_logs from anon;
+
+revoke insert, update, delete, truncate, references, trigger
+  on table admin_users, activity_logs from authenticated;
+
+-- RLS does not apply to TRUNCATE -- it is the one statement a policy cannot
+-- restrict -- so it has to be revoked rather than gated.
+revoke truncate on table team_departments, team_members, events, startups, media
+  from anon, authenticated;

--- a/supabase/migrations/0004_storage_policies.sql
+++ b/supabase/migrations/0004_storage_policies.sql
@@ -1,0 +1,124 @@
+-- Storage object policies for the 4 buckets created in 0002.
+-- Owner: Database + API. Spec: docs/SCHEMA.md ("Storage buckets").
+--
+-- Same access model as the content tables: public read, admin-only write,
+-- with `is_admin()` (defined in 0001) as the single gate.
+--
+-- Like 0003, this first drops policies that were created by hand in the
+-- Supabase SQL editor. All four were `to public` with a `true` expression and
+-- no bucket_id scoping at all, which meant any anon caller could upload,
+-- overwrite, or delete any object in any bucket -- arbitrary file hosting under
+-- the project's domain.
+--
+-- Note on reads: these buckets are `public = true`, so the CDN route
+-- (/storage/v1/object/public/<bucket>/<path>) serves objects without consulting
+-- RLS. The select policies below govern the authenticated API route. Reads are
+-- public either way -- that is intended, these are website images -- but do not
+-- read the select policy as if it were hiding anything.
+--
+-- Policy names must be unique across storage.objects as a whole, hence the
+-- bucket-name prefix on each.
+
+-- ---------------------------------------------------------------------------
+-- 1. Drop the hand-created permissive policies
+-- ---------------------------------------------------------------------------
+drop policy if exists "Public storage read"   on storage.objects;
+drop policy if exists "Public storage insert" on storage.objects;
+drop policy if exists "Public storage update" on storage.objects;
+drop policy if exists "Public storage delete" on storage.objects;
+
+-- ---------------------------------------------------------------------------
+-- 2. team-photos -- team_members.image_url
+-- ---------------------------------------------------------------------------
+create policy team_photos_select_all
+  on storage.objects for select
+  to anon, authenticated
+  using (bucket_id = 'team-photos');
+
+create policy team_photos_insert_admin
+  on storage.objects for insert
+  to authenticated
+  with check (bucket_id = 'team-photos' and (select is_admin()));
+
+create policy team_photos_update_admin
+  on storage.objects for update
+  to authenticated
+  using (bucket_id = 'team-photos' and (select is_admin()))
+  with check (bucket_id = 'team-photos' and (select is_admin()));
+
+create policy team_photos_delete_admin
+  on storage.objects for delete
+  to authenticated
+  using (bucket_id = 'team-photos' and (select is_admin()));
+
+-- ---------------------------------------------------------------------------
+-- 3. event-images -- events.image_url
+-- ---------------------------------------------------------------------------
+create policy event_images_select_all
+  on storage.objects for select
+  to anon, authenticated
+  using (bucket_id = 'event-images');
+
+create policy event_images_insert_admin
+  on storage.objects for insert
+  to authenticated
+  with check (bucket_id = 'event-images' and (select is_admin()));
+
+create policy event_images_update_admin
+  on storage.objects for update
+  to authenticated
+  using (bucket_id = 'event-images' and (select is_admin()))
+  with check (bucket_id = 'event-images' and (select is_admin()));
+
+create policy event_images_delete_admin
+  on storage.objects for delete
+  to authenticated
+  using (bucket_id = 'event-images' and (select is_admin()));
+
+-- ---------------------------------------------------------------------------
+-- 4. startup-images -- startups.image_url
+-- ---------------------------------------------------------------------------
+create policy startup_images_select_all
+  on storage.objects for select
+  to anon, authenticated
+  using (bucket_id = 'startup-images');
+
+create policy startup_images_insert_admin
+  on storage.objects for insert
+  to authenticated
+  with check (bucket_id = 'startup-images' and (select is_admin()));
+
+create policy startup_images_update_admin
+  on storage.objects for update
+  to authenticated
+  using (bucket_id = 'startup-images' and (select is_admin()))
+  with check (bucket_id = 'startup-images' and (select is_admin()));
+
+create policy startup_images_delete_admin
+  on storage.objects for delete
+  to authenticated
+  using (bucket_id = 'startup-images' and (select is_admin()));
+
+-- ---------------------------------------------------------------------------
+-- 5. media-gallery -- standalone Media Manager uploads
+-- ---------------------------------------------------------------------------
+create policy media_gallery_select_all
+  on storage.objects for select
+  to anon, authenticated
+  using (bucket_id = 'media-gallery');
+
+create policy media_gallery_insert_admin
+  on storage.objects for insert
+  to authenticated
+  with check (bucket_id = 'media-gallery' and (select is_admin()));
+
+create policy media_gallery_update_admin
+  on storage.objects for update
+  to authenticated
+  using (bucket_id = 'media-gallery' and (select is_admin()))
+  with check (bucket_id = 'media-gallery' and (select is_admin()));
+
+create policy media_gallery_delete_admin
+  on storage.objects for delete
+  to authenticated
+  using (bucket_id = 'media-gallery' and (select is_admin()));

--- a/supabase/migrations/0005_seed_initial_content.sql
+++ b/supabase/migrations/0005_seed_initial_content.sql
@@ -1,0 +1,155 @@
+-- One-off seed: migrate the site's committed JSON into Postgres so the admin
+-- panel and public site have real data to build against.
+-- Owner: Database + API.
+--
+--   ../team.json        -> team_departments (4) + team_members (5)
+--   ../startups.json    -> startups (6)
+--   ../data/media.json  -> media (21)
+--
+-- Shipped as a migration rather than via supabase/seed.sql because `db push`
+-- does not run seed.sql against a remote project -- it only runs on a local
+-- `db reset`. As a migration it is reviewable in the PR and cannot be forgotten
+-- by whoever applies it.
+--
+-- Image paths are kept exactly as they appear in the JSON ("images/...", served
+-- from the GitHub Pages site). Nothing is uploaded to Storage today; that
+-- happens later through the Media Manager. Accordingly media.storage_path is
+-- left NULL, which 0003 made possible and which is how a row says "legacy file,
+-- not in a bucket".
+--
+-- Every insert is `on conflict ... do nothing` against a real unique key, so
+-- re-running this is a no-op rather than a duplicate. The keys are slug
+-- (team_departments, startups, both from 0001), (department_id, name)
+-- (team_members) and url (media), the latter two added in 0003.
+--
+-- Notes on the mapping, where the JSON and the schema disagree:
+--   * startups.json "id"        -> slug, lowercased ("MatPlus" -> "matplus")
+--   * startups.json "alt"       -> image_alt
+--   * startups.json "test_url"  -> demo_url    (renamed in the schema)
+--   * startups.json "test_text" -> demo_text
+--   * startups.tags has no source in the JSON and seeds empty; it is an
+--     admin-editable field and nothing on the public site renders it yet.
+--   * team.json only contains team leads, so all 5 members get is_lead = true.
+--     There is no source of non-lead members to seed.
+--   * data/media.json is a bare array of paths with no alt text; the alt_text
+--     below is written here rather than derived, replacing the camelCase-split
+--     filenames the gallery currently generates client-side.
+--
+-- sort_order preserves the existing display order in each JSON file.
+
+-- ---------------------------------------------------------------------------
+-- 1. team_departments  <- team.json
+-- ---------------------------------------------------------------------------
+insert into team_departments (slug, title, subtitle, description, link_url, link_text, sort_order)
+values
+  ('engineering', 'Engineering Team', 'Design, code, deploy',
+   'Whether it''s full-stack app development, system design, AI engineering, or simple API calls, it''s hard to have ideas that don''t need some type of engineering support these days. These engineers help design, code, and deploy ideas.',
+   'https://github.com/ac-i2i-engineering', 'GitHub Organization →', 0),
+
+  ('financing', 'Financing Team', 'Fund, manage, advise',
+   'From grants to crowd-sourcing, there are various approaches to equip student ideas with monetary resources. But startups must be efficient and prudent with their limited finances. This team advises students on financial actions and strategy.',
+   null, null, 1),
+
+  ('creative', 'Creative Team', 'Curate a story',
+   'Communication is the cornerstone of innovation. This is a team of storytellers who can transform concepts into compelling narratives and visual experiences. These members lead design and content production for i2i and student ideas in need of a voice.',
+   null, null, 2),
+
+  ('consulting', 'Consulting Team', 'Work 1:1 with startups',
+   'We have a myriad of resources for big dreamers, and we want to make it effortless for ideas to grow. This team works 1-on-1 with students to facilitate the execution of their ideas by connecting all the pieces of i2i together.',
+   null, null, 3)
+on conflict (slug) do nothing;
+
+-- ---------------------------------------------------------------------------
+-- 2. team_members  <- team.json "leaders"
+-- ---------------------------------------------------------------------------
+-- department_id is resolved by joining on the slug rather than hardcoding the
+-- generated uuids, so this stays correct on any database.
+insert into team_members (department_id, name, role, image_url, alt_text, is_lead, sort_order, is_published)
+select d.id, v.name, v.role, v.image_url, v.alt_text, true, v.sort_order, true
+from (values
+  ('engineering', 'Ryan Ji',          'Executive Director of Engineering', 'images/ryan_ji.JPG',         'Ryan Ji - Engineering Team Lead',          0),
+  ('engineering', 'Liam Davis',       'Executive Director of Engineering', 'images/liam_davis.jpg',      'Liam Davis - Engineering Team Lead',       1),
+  ('financing',   'Nikolai Dammholz', 'Executive Director of Financing',   'images/financing-lead.png',  'Nikolai Dammholz - Financing Team Lead',   0),
+  ('creative',    'Claire Liu',       'Executive Director of Creative',    'images/creative-lead.png',   'Claire Liu - Creative Team Lead',          0),
+  ('consulting',  'Alex Nichols',     'Executive Director of Consulting',  'images/catalyst-lead.png',   'Alex Nichols - Consulting Team Lead',      0)
+) as v (dept_slug, name, role, image_url, alt_text, sort_order)
+join team_departments d on d.slug = v.dept_slug
+on conflict (department_id, name) do nothing;
+
+-- ---------------------------------------------------------------------------
+-- 3. startups  <- startups.json
+-- ---------------------------------------------------------------------------
+insert into startups (slug, title, description, image_url, image_alt,
+                      github_url, github_text, demo_url, demo_text,
+                      tags, sort_order, is_published)
+values
+  ('amherst-connect', 'Amherst Connect',
+   'Database and interface for events at Amherst. One-stop shop for looking at the big pictures of all events at Amherst!',
+   'images/Amherst-Connect.png', 'Amherst Connect',
+   'https://github.com/ac-i2i-engineering/access-amherst', 'GitHub Project Repository→',
+   'https://amherst-connect.com/', 'Test the App→',
+   '{}', 0, true),
+
+  ('matching-engine', 'Matching Engine',
+   'This is the matching engine we are building to match students with each other & ideas!',
+   'images/Matching-Engine.png', 'Matching Engine',
+   'https://github.com/ac-i2i-engineering/matching-engine', 'GitHub Project Repository→',
+   null, null,
+   '{}', 1, true),
+
+  ('amherst-coursework', 'Amherst Coursework',
+   'Amherst Coursework is a web application that provides Amherst College students and faculty with an intuitive, advanced interface for course search.',
+   'images/amherst_coursework.png', 'Amherst Coursework',
+   'https://github.com/ac-i2i-engineering/amherst-coursework', 'GitHub Project Repository→',
+   'https://amherstcourses.com/', 'Test the App→',
+   '{}', 2, true),
+
+  ('resumax', 'Resumax',
+   'Resumax is an AI chatbot designed to help students enhance their resumes effectively.',
+   'images/resumax.png', 'Resumax',
+   'https://github.com/ac-i2i-engineering/resumax', 'GitHub Project Repository→',
+   null, null,
+   '{}', 3, true),
+
+  ('matplus', 'MatPlus',
+   'A Python package for effortlessly creating stunning plots.',
+   'images/mat_plus.png', 'MatPlus',
+   'https://github.com/ac-i2i-engineering/mat-plus', 'GitHub Project Repository→',
+   null, null,
+   '{}', 4, true),
+
+  ('lost-and-found', 'Amherst Lost and Found',
+   'Each year, campuses gather tons of lost items—many go to landfills. Our Django-based Amherst Lost & Found app uses AI and maps to reunite items with owners, cutting waste and helping the planet.',
+   'images/amherst-lost-and-found.png', 'Amherst Lost and Found',
+   'https://github.com/Tetsuya787/LostandFound', 'GitHub Project Repository→',
+   null, null,
+   '{}', 5, true)
+on conflict (slug) do nothing;
+
+-- ---------------------------------------------------------------------------
+-- 4. media  <- data/media.json
+-- ---------------------------------------------------------------------------
+insert into media (storage_path, url, alt_text, sort_order)
+values
+  (null, 'images/Media-Gallery/TeamDiscussion3.jpg', 'i2i members in discussion',        0),
+  (null, 'images/Media-Gallery/Coding4.jpg',         'i2i members working on code',      1),
+  (null, 'images/Media-Gallery/TeamPhoto2.jpg',      'i2i team photo',                   2),
+  (null, 'images/Media-Gallery/Brainstorm1.jpg',     'i2i brainstorming session',        3),
+  (null, 'images/Media-Gallery/TeamDiscussion7.jpg', 'i2i members in discussion',        4),
+  (null, 'images/Media-Gallery/Coding1.jpg',         'i2i members working on code',      5),
+  (null, 'images/Media-Gallery/TeamPhoto4.jpg',      'i2i team photo',                   6),
+  (null, 'images/Media-Gallery/TeamDiscussion1.jpg', 'i2i members in discussion',        7),
+  (null, 'images/Media-Gallery/Mentorship2.jpg',     'i2i mentorship session',           8),
+  (null, 'images/Media-Gallery/Working1.jpg',        'i2i members working together',     9),
+  (null, 'images/Media-Gallery/TeamDiscussion4.jpg', 'i2i members in discussion',       10),
+  (null, 'images/Media-Gallery/Coding3.jpg',         'i2i members working on code',     11),
+  (null, 'images/Media-Gallery/TeamPhoto1.jpg',      'i2i team photo',                  12),
+  (null, 'images/Media-Gallery/TeamDiscussion8.jpg', 'i2i members in discussion',       13),
+  (null, 'images/Media-Gallery/TeamDiscussion2.jpg', 'i2i members in discussion',       14),
+  (null, 'images/Media-Gallery/TeamPhoto5.jpg',      'i2i team photo',                  15),
+  (null, 'images/Media-Gallery/Coding5.jpg',         'i2i members working on code',     16),
+  (null, 'images/Media-Gallery/TeamDiscussion5.jpg', 'i2i members in discussion',       17),
+  (null, 'images/Media-Gallery/Mentorship1.jpg',     'i2i mentorship session',          18),
+  (null, 'images/Media-Gallery/Brainstorm2.jpg',     'i2i brainstorming session',       19),
+  (null, 'images/Media-Gallery/TeamPhoto3.jpg',      'i2i team photo',                  20)
+on conflict (url) do nothing;

--- a/supabase/migrations/0006_dashboard_stats.sql
+++ b/supabase/migrations/0006_dashboard_stats.sql
@@ -1,0 +1,69 @@
+-- Home dashboard stats, as a single RPC.
+-- Owner: Database + API. Consumer: UI (admin Home page), via
+-- admin/lib/queries/stats.ts.
+--
+-- The dashboard needs, per card: a total, a count updated in the last 7 days,
+-- and the most recent updated_at -- plus an "upcoming" count for Events. Doing
+-- that with supabase-js `count: 'exact', head: true` calls is 13 round trips to
+-- render one page; this returns the whole thing in one.
+--
+-- SECURITY INVOKER (the default, stated explicitly because it matters here):
+-- the function runs with the caller's privileges, so RLS still applies. An anon
+-- caller counts only published rows; a signed-in admin counts everything. There
+-- is no separate authorization check to keep in sync -- the policies from 0003
+-- do the work. Making this SECURITY DEFINER would leak unpublished counts to
+-- logged-out visitors.
+--
+-- Returns:
+--   { "teamMembers": { total, updatedLast7Days, lastUpdatedAt },
+--     "events":      { total, updatedLast7Days, lastUpdatedAt, upcoming },
+--     "startups":    { ... }, "media": { ... } }
+-- Keys are camelCase to match the TypeScript interfaces they deserialize into.
+
+create or replace function get_dashboard_stats()
+returns json
+language sql
+stable
+security invoker
+set search_path = public
+as $$
+  select json_build_object(
+    'teamMembers', (
+      select json_build_object(
+        'total',            count(*),
+        'updatedLast7Days', count(*) filter (where updated_at >= now() - interval '7 days'),
+        'lastUpdatedAt',    max(updated_at)
+      ) from team_members
+    ),
+    'events', (
+      select json_build_object(
+        'total',            count(*),
+        'updatedLast7Days', count(*) filter (where updated_at >= now() - interval '7 days'),
+        'lastUpdatedAt',    max(updated_at),
+        -- "Upcoming" is relative to the college's local date, not the server's.
+        -- The database runs in UTC, so a plain current_date would roll over at
+        -- 8pm Amherst time and drop the same evening's event from the count.
+        'upcoming',         count(*) filter (
+                              where is_published
+                                and event_date >= (now() at time zone 'America/New_York')::date
+                            )
+      ) from events
+    ),
+    'startups', (
+      select json_build_object(
+        'total',            count(*),
+        'updatedLast7Days', count(*) filter (where updated_at >= now() - interval '7 days'),
+        'lastUpdatedAt',    max(updated_at)
+      ) from startups
+    ),
+    'media', (
+      select json_build_object(
+        'total',            count(*),
+        'updatedLast7Days', count(*) filter (where updated_at >= now() - interval '7 days'),
+        'lastUpdatedAt',    max(updated_at)
+      ) from media
+    )
+  );
+$$;
+
+grant execute on function get_dashboard_stats() to anon, authenticated;


### PR DESCRIPTION
Deliverables 1-6: RLS policies on all 7 tables (0003), 16 storage policies (0004), seed data from the committed JSON (0005), and a dashboard stats RPC (0006) -- plus repair of schema drift from hand-applied migrations, which had left 14 `using (true)` policies live that existed in no file. Verified with 65 checks against the live project; a signed-in user who is not in `admin_users` remains untested.