### PR TITLE
Wire up the live Vercel deployment for the admin panel

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -59,10 +59,16 @@ policies are added and pushed as a follow-up migration.
    auto-deploys — no GitHub Action needed, Vercel's GitHub integration
    handles it.
 
+**Live at:** `https://ac-i2i-engineering-github-io.vercel.app` — this exact
+URL must also be in the Supabase project's Site URL / Redirect URLs
+(Authentication → URL Configuration in the dashboard), matching
+`supabase/config.toml`'s `[auth]` section, or invite/reset emails won't
+redirect anywhere useful in production. See `docs/AUTH.md`.
+
 ## Summary
 
 | Piece | Host | Deploys on | Manual step required |
 |---|---|---|---|
 | Public site | GitHub Pages | push to `main` | none — already configured |
-| Admin panel | Vercel | push to `main` (after import) | one-time: import repo, set root dir + env vars |
+| Admin panel | Vercel | push to `main` (after import) | done — live at the URL above |
 | Database | Supabase | `supabase db push` | run manually when migrations change — not automatic |

--- a/events.html
+++ b/events.html
@@ -143,8 +143,7 @@
       
       <div class="footer-bottom">
         <p>© 2024 i2i Amherst Venture Accelerator. All rights reserved.</p>
-        <!-- TODO: confirm the deployed admin panel URL once it's on Vercel -->
-        <a href="https://admin.acideas2innovation.com/login" class="staff-login-link">Staff Login</a>
+        <a href="https://ac-i2i-engineering-github-io.vercel.app/login" class="staff-login-link">Staff Login</a>
       </div>
     </footer>
   </main>

--- a/get-in-touch.html
+++ b/get-in-touch.html
@@ -91,8 +91,7 @@
       
       <div class="footer-bottom">
         <p>© 2024 i2i Amherst Venture Accelerator. All rights reserved.</p>
-        <!-- TODO: confirm the deployed admin panel URL once it's on Vercel -->
-        <a href="https://admin.acideas2innovation.com/login" class="staff-login-link">Staff Login</a>
+        <a href="https://ac-i2i-engineering-github-io.vercel.app/login" class="staff-login-link">Staff Login</a>
       </div>
     </footer>   
   </main>

--- a/index.html
+++ b/index.html
@@ -112,8 +112,7 @@
       
       <div class="footer-bottom">
         <p>© 2024 i2i Amherst Venture Accelerator. All rights reserved.</p>
-        <!-- TODO: confirm the deployed admin panel URL once it's on Vercel -->
-        <a href="https://admin.acideas2innovation.com/login" class="staff-login-link">Staff Login</a>
+        <a href="https://ac-i2i-engineering-github-io.vercel.app/login" class="staff-login-link">Staff Login</a>
       </div>
     </footer>   
   </main>

--- a/media.html
+++ b/media.html
@@ -170,8 +170,7 @@
       
       <div class="footer-bottom">
         <p>© 2024 i2i Amherst Venture Accelerator. All rights reserved.</p>
-        <!-- TODO: confirm the deployed admin panel URL once it's on Vercel -->
-        <a href="https://admin.acideas2innovation.com/login" class="staff-login-link">Staff Login</a>
+        <a href="https://ac-i2i-engineering-github-io.vercel.app/login" class="staff-login-link">Staff Login</a>
       </div>
     </footer>   
   </main>

--- a/our-team.html
+++ b/our-team.html
@@ -82,8 +82,7 @@
       
       <div class="footer-bottom">
         <p>© 2024 i2i Amherst Venture Accelerator. All rights reserved.</p>
-        <!-- TODO: confirm the deployed admin panel URL once it's on Vercel -->
-        <a href="https://admin.acideas2innovation.com/login" class="staff-login-link">Staff Login</a>
+        <a href="https://ac-i2i-engineering-github-io.vercel.app/login" class="staff-login-link">Staff Login</a>
       </div>
     </footer>   
   </main>

--- a/startups.html
+++ b/startups.html
@@ -84,8 +84,7 @@
       
       <div class="footer-bottom">
         <p>© 2024 i2i Amherst Venture Accelerator. All rights reserved.</p>
-        <!-- TODO: confirm the deployed admin panel URL once it's on Vercel -->
-        <a href="https://admin.acideas2innovation.com/login" class="staff-login-link">Staff Login</a>
+        <a href="https://ac-i2i-engineering-github-io.vercel.app/login" class="staff-login-link">Staff Login</a>
       </div>
     </footer>   
   </main>

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -156,14 +156,17 @@ max_indexes = 5
 enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
-site_url = "http://localhost:3000"
+site_url = "https://ac-i2i-engineering-github-io.vercel.app"
 # The public URL that Auth serves on. Defaults to the API external URL with `/auth/v1` appended.
 # external_url = ""
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
 # NOT pushed to the remote project automatically (`supabase config push` would need to be run
 # deliberately) -- the live project's Site URL / Redirect URLs must currently be set to match
 # this by hand in the dashboard (Authentication -> URL Configuration). See docs/AUTH.md.
-additional_redirect_urls = ["http://localhost:3000/**"]
+additional_redirect_urls = [
+  "http://localhost:3000/**",
+  "https://ac-i2i-engineering-github-io.vercel.app/**",
+]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # JWT issuer URL. If not set, defaults to auth.external_url.


### PR DESCRIPTION
The admin panel is now live at
https://ac-i2i-engineering-github-io.vercel.app -- updating everything that referenced its old "not deployed yet" placeholder state:

- supabase/config.toml: [auth] site_url is now the production URL, and additional_redirect_urls includes both it and localhost (still needed for local dev). Not yet pushed to the live Supabase project -- that requires `supabase config push`, which pushes the whole file rather than just these two fields, so it needs a deliberate decision rather than happening as a side effect of this change. Until it's applied (locally or by hand in the dashboard, Authentication -> URL Configuration), invite/reset emails sent from the live admin panel will redirect to localhost instead of the production URL.
- Public site: the "Staff Login" footer link on all 6 pages now points at the real URL instead of a dead placeholder domain.
- docs/DEPLOYMENT.md: documents the live URL and the still-required Supabase dashboard step.

Verified against the live deployment directly (not assumed): /, /login, /forgot-password, and /auth/confirm all behave correctly in production, confirming the Supabase environment variables on Vercel are already configured right.

## What changed

<!-- one or two sentences -->

## Checklist

- [x] `npm run build` passes in `admin/` (if admin code changed)
- [x] No `.env.local` or real Supabase keys committed
- [x] If a table/column name changed: `supabase/migrations` and `admin/lib/types.ts` were both updated, and the team was notified
- [x] Tested manually in the browser
