### PR TITLE
Replace email invite links with a temp-password onboarding flow

### DIFF
--- a/admin/app/(protected)/layout.tsx
+++ b/admin/app/(protected)/layout.tsx
@@ -10,6 +10,13 @@ export default async function ProtectedLayout({ children }: { children: React.Re
     redirect("/login");
   }
 
+  // Invited via a temp password (see /api/admin/invite) -- must set a real
+  // one before reaching anything else. /set-password isn't under this
+  // layout, so this doesn't loop.
+  if (session.admin.must_reset_password) {
+    redirect("/set-password");
+  }
+
   return (
     <SessionProvider session={session}>
       <AdminLayout user={session}>{children}</AdminLayout>

--- a/admin/app/(protected)/settings/page.tsx
+++ b/admin/app/(protected)/settings/page.tsx
@@ -12,6 +12,8 @@ import {
   NativeSelect,
   VStack,
   SimpleGrid,
+  Dialog,
+  Code,
 } from "@chakra-ui/react";
 import { DataTable, ColumnDef } from "@/components/ui/DataTable";
 import { ModalFormWrapper } from "@/components/ui/ModalFormWrapper";
@@ -34,6 +36,7 @@ export default function SettingsPage() {
   const [inviteFullName, setInviteFullName] = useState("");
   const [sending, setSending] = useState(false);
   const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+  const [issuedCredential, setIssuedCredential] = useState<{ email: string; tempPassword: string } | null>(null);
 
   const [statusTarget, setStatusTarget] = useState<AdminUser | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<AdminUser | null>(null);
@@ -82,9 +85,9 @@ export default function SettingsPage() {
       const data = await res.json();
 
       if (res.ok && data.user) {
-        setMessage({ type: "success", text: `Invitation sent to ${inviteEmail}` });
         setAdminUsers((prev) => [data.user, ...prev]);
         setIsInviteOpen(false);
+        setIssuedCredential({ email: inviteEmail, tempPassword: data.tempPassword });
         setInviteEmail("");
         setInviteFullName("");
         setInviteRole("admin");
@@ -398,6 +401,59 @@ export default function SettingsPage() {
           </Box>
         </VStack>
       </ModalFormWrapper>
+
+      {/* Temp password, shown exactly once -- not recoverable after this closes */}
+      <Dialog.Root open={!!issuedCredential} onOpenChange={(e) => !e.open && setIssuedCredential(null)}>
+        <Dialog.Backdrop bg="rgba(0, 0, 0, 0.75)" backdropFilter="blur(8px)" />
+        <Dialog.Positioner>
+          <Dialog.Content bg="#0F172A" border="1px solid rgba(255, 255, 255, 0.12)" borderRadius="2xl" maxW="440px" p={6} color="white">
+            <Dialog.Header>
+              <Dialog.Title color="white" fontWeight="bold">
+                Admin account created
+              </Dialog.Title>
+            </Dialog.Header>
+            <Dialog.Body my={3}>
+              <Text color="gray.400" fontSize="sm" mb={4}>
+                Share this temporary password with <b>{issuedCredential?.email}</b> directly (Slack, text, in
+                person) -- not email. It won&apos;t be shown again. They&apos;ll be required to set their own
+                password the first time they sign in.
+              </Text>
+              <Code
+                display="block"
+                p={3}
+                borderRadius="lg"
+                fontSize="md"
+                bg="rgba(99, 102, 241, 0.12)"
+                color="#A5B4FC"
+                textAlign="center"
+                userSelect="all"
+              >
+                {issuedCredential?.tempPassword}
+              </Code>
+            </Dialog.Body>
+            <Dialog.Footer gap={3}>
+              <Button
+                variant="outline"
+                borderColor="rgba(255, 255, 255, 0.15)"
+                color="gray.300"
+                onClick={() => {
+                  if (issuedCredential) navigator.clipboard?.writeText(issuedCredential.tempPassword);
+                }}
+              >
+                Copy
+              </Button>
+              <Button
+                bg="linear-gradient(135deg, #6366F1 0%, #8B5CF6 100%)"
+                color="white"
+                fontWeight="bold"
+                onClick={() => setIssuedCredential(null)}
+              >
+                Done
+              </Button>
+            </Dialog.Footer>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Dialog.Root>
 
       {/* Suspend/Reactivate confirmation */}
       <ConfirmDialog

--- a/admin/app/api/account/clear-must-reset/route.ts
+++ b/admin/app/api/account/clear-must-reset/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { createClient as createServiceClient } from "@supabase/supabase-js";
+import { createClient as createServerClient } from "@/lib/supabase/server";
+
+// Called by /set-password right after a successful password change, for
+// both the temp-password-invite path (must_reset_password was true) and the
+// ordinary forgot-password path (already false -- a harmless no-op there).
+// Scoped to the caller's own row only, taken from their session, never from
+// the request body -- admin_users has no client-write RLS policy at all, so
+// this must never accept an arbitrary id.
+export async function POST() {
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Not signed in" }, { status: 401 });
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    return NextResponse.json(
+      { error: "Server is missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY" },
+      { status: 500 },
+    );
+  }
+
+  const supabaseAdmin = createServiceClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  const { error } = await supabaseAdmin
+    .from("admin_users")
+    .update({ must_reset_password: false })
+    .eq("id", user.id);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/admin/app/api/admin/invite/route.ts
+++ b/admin/app/api/admin/invite/route.ts
@@ -1,6 +1,17 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
+import { randomBytes } from "node:crypto";
 import { getAdminSession } from "@/lib/auth/session";
+
+// Not sent anywhere -- returned once in this route's response so the
+// inviting admin can copy it and share it out-of-band (Slack, in person).
+// Avoids depending on Supabase's own email sending for onboarding, which is
+// rate-limited to a couple of emails/hour on the default sender. Self-service
+// "Forgot password" (email-based) is kept as the recovery path for later, so
+// there's no single point of failure if the inviting admin isn't reachable.
+function generateTempPassword(): string {
+  return randomBytes(9).toString("base64url"); // 12 chars, well past the 8-char minimum
+}
 
 export async function POST(request: Request) {
   try {
@@ -37,19 +48,60 @@ export async function POST(request: Request) {
     });
 
     // admin_users.id is a PK that references auth.users(id) with no default,
-    // so it must come from a real Auth user -- inviteUserByEmail must
-    // succeed before there's anything to insert.
-    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || new URL(request.url).origin;
-    const { data: authData, error: authErr } = await supabaseAdmin.auth.admin.inviteUserByEmail(email, {
-      redirectTo: `${siteUrl}/auth/confirm?next=/set-password`,
+    // so it must come from a real Auth user -- this must succeed before
+    // there's anything to insert.
+    const tempPassword = generateTempPassword();
+    let authUser: { id: string };
+
+    const { data: authData, error: authErr } = await supabaseAdmin.auth.admin.createUser({
+      email,
+      password: tempPassword,
+      email_confirm: true,
     });
-    if (authErr || !authData?.user) {
+
+    if (!authErr && authData?.user) {
+      authUser = authData.user;
+    } else if (authErr?.code === "email_exists" || /already (been )?registered|already exists/i.test(authErr?.message ?? "")) {
+      // An Auth user for this email already exists -- most likely someone
+      // invited before this flow existed (the old inviteUserByEmail left a
+      // half-set-up Auth user with no password and no admin_users row).
+      // Reuse it, but only if it isn't already a real admin: resetting an
+      // existing admin's password here would be a silent account takeover.
+      const { data: existingAdminRow } = await supabaseAdmin
+        .from("admin_users")
+        .select("id")
+        .eq("email", email)
+        .maybeSingle();
+      if (existingAdminRow) {
+        return NextResponse.json({ error: `${email} is already an admin` }, { status: 409 });
+      }
+
+      const { data: list, error: listErr } = await supabaseAdmin.auth.admin.listUsers();
+      const existingAuthUser = list?.users.find((u) => u.email?.toLowerCase() === email.toLowerCase());
+      if (listErr || !existingAuthUser) {
+        return NextResponse.json(
+          { error: `Failed to look up existing Auth user: ${listErr?.message || "not found"}` },
+          { status: 500 },
+        );
+      }
+
+      const { data: updated, error: updateErr } = await supabaseAdmin.auth.admin.updateUserById(
+        existingAuthUser.id,
+        { password: tempPassword, email_confirm: true },
+      );
+      if (updateErr || !updated?.user) {
+        return NextResponse.json(
+          { error: `Failed to reset existing Auth user: ${updateErr?.message || "no user returned"}` },
+          { status: 500 },
+        );
+      }
+      authUser = updated.user;
+    } else {
       return NextResponse.json(
-        { error: `Failed to invite user via Supabase Auth: ${authErr?.message || "no user returned"}` },
+        { error: `Failed to create user via Supabase Auth: ${authErr?.message || "no user returned"}` },
         { status: 500 },
       );
     }
-    const authUser = authData.user;
 
     const newUser = {
       id: authUser.id,
@@ -57,6 +109,7 @@ export async function POST(request: Request) {
       full_name: fullName || email.split("@")[0],
       role: resolvedRole,
       status: "active" as const,
+      must_reset_password: true,
       created_at: new Date().toISOString(),
     };
 
@@ -72,8 +125,9 @@ export async function POST(request: Request) {
 
     return NextResponse.json({
       success: true,
-      message: `Invitation successfully sent and recorded for ${email}`,
+      message: `Admin account created for ${email}`,
       user: inserted,
+      tempPassword,
     });
   } catch (err) {
     console.error("Invite API error:", err);

--- a/admin/app/auth/confirm/route.ts
+++ b/admin/app/auth/confirm/route.ts
@@ -2,8 +2,9 @@ import { type EmailOtpType } from "@supabase/supabase-js";
 import { type NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
-// Where invite (inviteUserByEmail) and reset (resetPasswordForEmail) links
-// actually land. Neither @supabase/ssr's browser client nor the proxy
+// Where the forgot-password link (resetPasswordForEmail) actually lands --
+// invites no longer go through email at all, see docs/AUTH.md. Neither
+// @supabase/ssr's browser client nor the proxy
 // establishes a session just from loading a page with a token in the URL --
 // that only happens for the old implicit flow. The current default requires
 // exchanging the token server-side first, which is what this route does,

--- a/admin/app/set-password/page.tsx
+++ b/admin/app/set-password/page.tsx
@@ -5,13 +5,16 @@ import { useRouter } from "next/navigation";
 import { Box, Button, Field, Heading, Input, Stack, Text } from "@chakra-ui/react";
 import { createClient } from "@/lib/supabase/client";
 
-// Shared by two flows that both land here the same way -- inviteUserByEmail
-// (new admin) and resetPasswordForEmail (forgot password), both via their
-// redirectTo. Supabase's client SDK reads the token from the URL and
-// establishes a session automatically on load -- there's nothing to do here
-// except call updateUser with the new password once the form is submitted.
-// Copy stays generic since there's no reliable way to tell which flow sent
-// someone here.
+// Shared by three flows that all land here with a session already
+// established, just by different routes:
+//   - a temp-password invite (see /api/admin/invite), forced here by the
+//     protected layout while admin_users.must_reset_password is true
+//   - resetPasswordForEmail (forgot password), via /auth/confirm
+//   - an invited/reset user who already has a session but revisits this URL
+// All three just need updateUser with the new password, then a call to
+// clear must_reset_password (a harmless no-op for the two paths where it
+// was already false). Copy stays generic since there's no reliable way to
+// tell which flow sent someone here.
 export default function SetPasswordPage() {
   const router = useRouter();
   const [password, setPassword] = useState("");
@@ -35,13 +38,19 @@ export default function SetPasswordPage() {
     setLoading(true);
     const supabase = createClient();
     const { error: updateError } = await supabase.auth.updateUser({ password });
-    setLoading(false);
 
     if (updateError) {
+      setLoading(false);
       setError(updateError.message);
       return;
     }
 
+    await fetch("/api/account/clear-must-reset", { method: "POST" }).catch(() => {
+      // Non-fatal -- worst case they're asked to set a password again next
+      // login, not locked out or left insecure.
+    });
+
+    setLoading(false);
     router.push("/");
     router.refresh();
   }

--- a/admin/lib/types.ts
+++ b/admin/lib/types.ts
@@ -87,6 +87,7 @@ export interface AdminUser {
   full_name: string | null;
   role: AdminRole;
   status: AdminStatus;
+  must_reset_password: boolean;
   created_at: string;
 }
 

--- a/admin/scripts/bootstrap-owner.mjs
+++ b/admin/scripts/bootstrap-owner.mjs
@@ -3,7 +3,11 @@
 // client-write path at all (see docs/SCHEMA.md), so the first Owner can't be
 // created through the app -- same reason Django ships `createsuperuser` and
 // Rails ships seed scripts. Every Owner/Admin after this one is created
-// through the app's "invite" flow instead.
+// through the app's "invite" flow instead (a temp password, not email).
+//
+// Sets a real password directly at creation -- no invite email involved, so
+// bootstrapping doesn't depend on Supabase's email sending at all. You'll be
+// prompted for the password interactively.
 //
 // Usage:
 //   cd admin
@@ -16,6 +20,7 @@
 import { createClient } from "@supabase/supabase-js";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import readline from "node:readline/promises";
 import path from "node:path";
 
 function loadDotEnvLocal() {
@@ -59,21 +64,32 @@ if (existing) {
   process.exit(1);
 }
 
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
-const { data: invite, error: inviteErr } = await supabase.auth.admin.inviteUserByEmail(email, {
-  redirectTo: `${siteUrl}/auth/confirm?next=/set-password`,
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+const password = await rl.question("Set a password for this Owner account (min 8 characters): ");
+rl.close();
+
+if (!password || password.length < 8) {
+  console.error("Password must be at least 8 characters.");
+  process.exit(1);
+}
+
+const { data: created, error: createErr } = await supabase.auth.admin.createUser({
+  email,
+  password,
+  email_confirm: true,
 });
-if (inviteErr || !invite?.user) {
-  console.error("Failed to invite user via Supabase Auth:", inviteErr?.message ?? "no user returned");
+if (createErr || !created?.user) {
+  console.error("Failed to create user via Supabase Auth:", createErr?.message ?? "no user returned");
   process.exit(1);
 }
 
 const { error: insertErr } = await supabase.from("admin_users").insert([
   {
-    id: invite.user.id,
+    id: created.user.id,
     email,
     role: "owner",
     status: "active",
+    must_reset_password: false,
   },
 ]);
 
@@ -82,4 +98,4 @@ if (insertErr) {
   process.exit(1);
 }
 
-console.log(`Owner bootstrapped: ${email}. They'll receive an invite email to set their password.`);
+console.log(`Owner bootstrapped: ${email}. Sign in at /login with the password you just set.`);

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -70,19 +70,42 @@ script. One-time, run once against the live project:
 cd admin && node scripts/bootstrap-owner.mjs "person@example.com"
 ```
 
-This creates the Supabase Auth user (or reuses one if it already exists)
-and inserts the matching `admin_users` row with `role = 'owner'`. Requires
+You'll be prompted for a password interactively. The script creates the
+Supabase Auth user with that password directly (`email_confirm: true`, no
+invite email involved) and inserts the matching `admin_users` row with
+`role = 'owner'`, `must_reset_password = false`. Requires
 `SUPABASE_SERVICE_ROLE_KEY` in the environment — never run this against a
 project you don't control.
 
 ## Login flow
 
-- New admin gets an email (Supabase's `inviteUserByEmail`, triggered by
-  `/api/admin/invite`), clicks through, sets a password.
-- Forgot password: `/login` → "Forgot password?" → `/forgot-password` → email
-  with a link (Supabase's `resetPasswordForEmail`). Same mechanism as the
-  invite link, same destination page — `/set-password`'s copy stays generic
-  because there's no reliable way to tell which flow sent someone there.
+- **Bootstrapping the first Owner**: no email at all — `bootstrap-owner.mjs`
+  sets a real password directly (see above). They sign in at `/login`
+  immediately.
+- **Inviting a new admin**: `/api/admin/invite` creates the Supabase Auth
+  user directly with a random temporary password (`auth.admin.createUser`,
+  not `inviteUserByEmail`) and sets `admin_users.must_reset_password = true`.
+  The temp password is returned once in the API response and shown once in
+  the Settings UI, for the inviting admin to share out-of-band (Slack, text,
+  in person) — **not email**. The new admin signs in at `/login` with that
+  temp password like anyone else; `(protected)/layout.tsx` sees
+  `must_reset_password` and redirects them to `/set-password` before they
+  can reach anything else. Setting a real password there clears the flag
+  (`/api/account/clear-must-reset`, scoped to the caller's own row).
+  Deliberately not email-based: onboarding several admins in a short window
+  is exactly the pattern that hits Supabase's default sender's rate limit,
+  and the old invite-link flow depended on the browser establishing a
+  session purely from a URL token, which isn't how the current flow actually
+  works (see below) — signing in with a real password sidesteps both.
+- **Forgot password** (for an existing admin who's already set a real
+  password): `/login` → "Forgot password?" → `/forgot-password` → email with
+  a link (Supabase's `resetPasswordForEmail`), same `/auth/confirm` →
+  `/set-password` mechanism as before. Kept as self-service and email-based
+  on purpose — an admin-issued reset would mean anyone locked out depends on
+  another admin being reachable, a single point of failure for a 3-person
+  team. Used far less often than invites, so it's much less likely to hit
+  the rate limit in practice; still worth a real SMTP provider (see below)
+  before relying on it for anything time-sensitive.
 - From then on: `/login`, email + password.
 - No 2FA. Real security value, but real complexity for a trusted 3-person
   team on a deadline — easy to add later if the team grows.
@@ -90,43 +113,51 @@ project you don't control.
   `@supabase/ssr` + `admin/proxy.ts` (Next.js 16 renamed `middleware.ts`),
   the standard Next.js App Router pattern — nothing custom.
 
-### Why invite/reset links go through `/auth/confirm`, not straight to `/set-password`
+### Why the forgot-password link goes through `/auth/confirm`, not straight to `/set-password`
 
-Neither the proxy nor `@supabase/ssr`'s browser client turns an invite/reset
-link's token into a real session just by loading a page with it in the URL —
-that's only true of the old implicit flow. The current default requires an
-explicit exchange first: `admin/app/auth/confirm/route.ts` does that
-server-side (`verifyOtp` for a `token_hash`+`type` link, or
-`exchangeCodeForSession` for a `code` link — it isn't this app's choice
-which one Supabase sends, that's project-level email template config), sets
-the session cookie, then redirects to `next` (`/set-password`). Every
-`redirectTo` in this codebase points at `/auth/confirm?next=...`, never
-directly at the destination page, for this reason.
+Neither the proxy nor `@supabase/ssr`'s browser client turns a reset link's
+token into a real session just by loading a page with it in the URL — that's
+only true of the old implicit flow. The current default requires an explicit
+exchange first: `admin/app/auth/confirm/route.ts` does that server-side
+(`verifyOtp` for a `token_hash`+`type` link, or `exchangeCodeForSession` for
+a `code` link — it isn't this app's choice which one Supabase sends, that's
+project-level email template config), sets the session cookie, then
+redirects to `next` (`/set-password`). This is exactly the failure mode the
+temp-password invite flow above was built to avoid entirely for onboarding:
+a user who reaches `/set-password` via a forced redirect after signing in
+with a temp password already has a real session from `signInWithPassword`,
+no token-exchange step needed.
 
 ### Required Supabase dashboard configuration
 
-Invite/reset links redirect through the project's **Site URL**, which is
-dashboard config (Authentication → URL Configuration), not something an API
-call can override per-request — `redirectTo` only works for destinations
-already on the **Redirect URLs** allowlist there. `supabase/config.toml`
-documents the intended local-dev values (`site_url = "http://localhost:3000"`,
-`http://localhost:3000/**` in `additional_redirect_urls`), but that file is
-**not** synced to the live project automatically — `supabase config push`
-would need to be run deliberately, and it pushes the whole config, not just
-these two fields. Until then, set both by hand in the dashboard to match, or
-invite/reset links will land wherever the project's default Site URL is
-instead of `/auth/confirm`.
+The forgot-password link redirects through the project's **Site URL**, which
+is dashboard config (Authentication → URL Configuration), not something an
+API call can override per-request — `redirectTo` only works for
+destinations already on the **Redirect URLs** allowlist there.
+`supabase/config.toml` documents the intended local-dev values
+(`site_url = "http://localhost:3000"`, `http://localhost:3000/**` in
+`additional_redirect_urls`), but that file is **not** synced to the live
+project automatically — `supabase config push` would need to be run
+deliberately, and it pushes the whole config, not just these two fields.
+Until then, set both by hand in the dashboard to match, or the reset link
+will land wherever the project's default Site URL is instead of
+`/auth/confirm`.
 
 ### Email sending is rate-limited until a custom SMTP provider is configured
 
 Every Supabase project starts on a shared, heavily-throttled default email
-sender meant only for testing — a handful of invites/resets in quick
-succession is enough to hit "email rate limit exceeded." This isn't a bug
-in this app; every `auth.admin.inviteUserByEmail`/`resetPasswordForEmail`
-call goes through it until it's replaced. Before relying on invite/reset
-emails for real use (not just testing), configure a real provider under
-Project Settings → Authentication → SMTP Settings — Resend, SendGrid, and
-Postmark all have free tiers well above what a 3-person admin panel needs.
+sender meant only for testing — a handful of emails in quick succession is
+enough to hit "email rate limit exceeded." This isn't a bug in this app;
+every `auth.resetPasswordForEmail` call goes through it until it's replaced.
+Bootstrapping and inviting no longer send any email at all (see Login flow
+above), so this now only affects forgot-password. Before relying on it for
+real use (not just testing), configure a real provider under Project
+Settings → Authentication → SMTP Settings — Resend, SendGrid, and Postmark
+all have free tiers well above what a 3-person admin panel needs. Note that
+a personal Gmail account doesn't work well as a substitute SMTP provider —
+Supabase's own dashboard warns about this, since consumer Gmail isn't meant
+for automated/transactional sending and Google may throttle or flag it
+regardless of whether the credentials are correct.
 
 ## Entry point on the public site
 

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -19,7 +19,7 @@ names matching exactly.
 | `events` | Calendar events | published rows | yes |
 | `startups` | Projects/Startups showcase | published rows | yes |
 | `media` | Uploaded images, optionally attached to a team member/event/startup | all rows | yes |
-| `admin_users` | Allowlist of who can sign in to `/admin` and write data. `role` is `owner` \| `admin`; `status` is `active` \| `suspended` (`0009`) | admin-only | **no** — service_role only |
+| `admin_users` | Allowlist of who can sign in to `/admin` and write data. `role` is `owner` \| `admin`; `status` is `active` \| `suspended` (`0009`); `must_reset_password` forces a password change before first real use, set on invite (`0010`) | admin-only | **no** — service_role only |
 | `activity_logs` | Audit trail of content changes (optional/stretch) | admin-only | **no** — service_role only |
 
 "Admin write" is enforced by RLS via the `is_admin()` helper function, which

--- a/supabase/migrations/0010_must_reset_password.sql
+++ b/supabase/migrations/0010_must_reset_password.sql
@@ -1,0 +1,8 @@
+-- Supports the temp-password invite flow (see docs/AUTH.md): an invited
+-- admin is created with a one-time temp password instead of an email link,
+-- and must be forced to set a real one on first login before reaching any
+-- protected page. true only for the window between invite and that first
+-- password change; false for everyone else, including the bootstrapped
+-- Owner (who sets a real password directly, never a temp one).
+alter table admin_users
+  add column must_reset_password boolean not null default false;


### PR DESCRIPTION
Supabase's default email sender is rate-limited to a couple of emails/hour, and the old inviteUserByEmail flow depended on the browser establishing a session purely from a URL token -- both made onboarding admins unreliable.

Invites now create the Auth user directly with a random temp password (returned once in the API response for the inviting admin to share out-of-band), and admin_users.must_reset_password forces a real password change on first login before reaching any protected page. The bootstrap script for the first Owner works the same way -- a password set directly at creation, no email. Forgot-password stays exactly as it was: self-service, email-based, so no single admin becomes a point of failure for recovery.

## What changed

<!-- one or two sentences -->

## Checklist

- [x] `npm run build` passes in `admin/` (if admin code changed)
- [x] No `.env.local` or real Supabase keys committed
- [x] If a table/column name changed: `supabase/migrations` and `admin/lib/types.ts` were both updated, and the team was notified
- [x] Tested manually in the browser
