### PR TITLE
Wire up the Live System Activity Log with real data

### DIFF
--- a/admin/app/(protected)/page.tsx
+++ b/admin/app/(protected)/page.tsx
@@ -55,15 +55,7 @@ export default function HomePage() {
           .order("created_at", { ascending: false })
           .limit(5);
 
-        if (actData && actData.length > 0) {
-          setActivities(actData as ActivityLogItem[]);
-        } else {
-          setActivities([
-            { id: "1", action: "create", entity_type: "event", summary: "Created new hackathon event", created_at: new Date(Date.now() - 3600000).toISOString() },
-            { id: "2", action: "update", entity_type: "team_member", summary: "Updated department roles & leads", created_at: new Date(Date.now() - 7200000).toISOString() },
-            { id: "3", action: "create", entity_type: "startup", summary: "Added new NeuroTech startup entry", created_at: new Date(Date.now() - 86400000).toISOString() },
-          ]);
-        }
+        setActivities((actData as ActivityLogItem[]) ?? []);
       } catch (err) {
         console.warn("Failed to load stats", err);
       } finally {
@@ -223,6 +215,10 @@ export default function HomePage() {
               Fetching updates...
             </Text>
           </Flex>
+        ) : activities.length === 0 ? (
+          <Text fontSize="sm" color="gray.500" py={4}>
+            No activity yet. Actions taken across Team, Events, Projects, and Media will show up here.
+          </Text>
         ) : (
           <Box>
             {activities.map((act) => (

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -20,7 +20,7 @@ names matching exactly.
 | `startups` | Projects/Startups showcase | published rows | yes |
 | `media` | Uploaded images, optionally attached to a team member/event/startup | all rows | yes |
 | `admin_users` | Allowlist of who can sign in to `/admin` and write data. `role` is `owner` \| `admin`; `status` is `active` \| `suspended` (`0009`); `must_reset_password` forces a password change before first real use, set on invite (`0010`) | admin-only | **no** — service_role only |
-| `activity_logs` | Audit trail of content changes (optional/stretch) | admin-only | **no** — service_role only |
+| `activity_logs` | Audit trail of content changes, auto-populated by an `AFTER` trigger on `team_members`/`events`/`startups`/`media` (`0011`) | admin-only | **no** — trigger only (`security definer`), nothing writes here directly |
 
 "Admin write" is enforced by RLS via the `is_admin()` helper function, which
 checks `auth.uid()` exists in `admin_users` **and** `status = 'active'`
@@ -50,7 +50,7 @@ This is what is enforced:
 | `startups` | `using (is_published = true or is_admin())` | `is_admin()` |
 | `media` | `using (true)` — everyone | `is_admin()` |
 | `admin_users` | `using (is_admin())` | **no policy at all** — writes only via `service_role`, bypassing RLS entirely |
-| `activity_logs` | `using (is_admin())` | **no policy at all** — writes only via `service_role` |
+| `activity_logs` | `using (is_admin())` | **no policy at all** — populated only by the `log_activity()` trigger (`0011`), which is `security definer` and bypasses RLS the same way `service_role` would |
 
 Reads are scoped `to anon, authenticated` and writes `to authenticated`. A
 policy with no role list applies to `PUBLIC` — every role — which is how the

--- a/supabase/migrations/0011_activity_log_triggers.sql
+++ b/supabase/migrations/0011_activity_log_triggers.sql
@@ -1,0 +1,59 @@
+-- Wires up activity_logs, left as a stretch goal in 0001. Content mutations
+-- (team_members/events/startups/media) all go straight from the browser to
+-- Postgres via RLS -- there's no API route in the middle to log from -- so
+-- logging happens here instead, as an AFTER trigger on each table. That also
+-- means it can't be missed by a page that forgets to log a write: every
+-- insert/update/delete is captured no matter which admin page did it.
+--
+-- security definer because activity_logs deliberately has no insert policy
+-- for authenticated (see 0001/0003) -- same reasoning as is_admin()/is_owner().
+create or replace function log_activity()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  entity_type_val text := TG_ARGV[0];
+  actor uuid := auth.uid();
+  actor_email_val text;
+  row_data jsonb := to_jsonb(coalesce(new, old));
+  display_name text := coalesce(
+    row_data ->> 'title',
+    row_data ->> 'name',
+    row_data ->> 'caption',
+    row_data ->> 'alt_text',
+    'item'
+  );
+  summary_val text;
+begin
+  select email into actor_email_val from admin_users where id = actor;
+
+  summary_val := case tg_op
+    when 'INSERT' then 'Created ' || display_name
+    when 'UPDATE' then 'Updated ' || display_name
+    when 'DELETE' then 'Deleted ' || display_name
+  end;
+
+  insert into activity_logs (actor_id, actor_email, action, entity_type, entity_id, summary)
+  values (actor, actor_email_val, lower(tg_op), entity_type_val, coalesce(new.id, old.id), summary_val);
+
+  return coalesce(new, old);
+end;
+$$;
+
+create trigger team_members_activity_log
+  after insert or update or delete on team_members
+  for each row execute function log_activity('team_member');
+
+create trigger events_activity_log
+  after insert or update or delete on events
+  for each row execute function log_activity('event');
+
+create trigger startups_activity_log
+  after insert or update or delete on startups
+  for each row execute function log_activity('startup');
+
+create trigger media_activity_log
+  after insert or update or delete on media
+  for each row execute function log_activity('media');


### PR DESCRIPTION
activity_logs existed since the first migration but was flagged as a stretch goal -- nothing ever wrote to it, so the dashboard always fell back to 3 hardcoded fake entries that never changed no matter what admins did.

Content mutations (team_members/events/startups/media) go straight from the browser to Postgres via RLS, with no API route in between to log from, so logging is now a database trigger instead: log_activity() runs after every insert/update/delete on those four tables and records the real actor and a human-readable summary. Can't be missed by a page forgetting to log, since it's enforced at the table level. Removed the fake fallback rows in favor of a real empty state.

## What changed

<!-- one or two sentences -->

## Checklist

- [x] `npm run build` passes in `admin/` (if admin code changed)
- [x] No `.env.local` or real Supabase keys committed
- [x] If a table/column name changed: `supabase/migrations` and `admin/lib/types.ts` were both updated, and the team was notified
- [x] Tested manually in the browser
