### PR TITLE
Media Manager: fix broken bucket filter, redesign cards around capture date

### DIFF
--- a/admin/app/(protected)/media/page.tsx
+++ b/admin/app/(protected)/media/page.tsx
@@ -19,12 +19,11 @@ import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { ImageUploader } from "@/components/ui/ImageUploader";
 import { PublishToggle } from "@/components/ui/PublishToggle";
 import { createClient } from "@/lib/supabase/client";
-import { STORAGE_BUCKETS, Media, MediaAttachedToType } from "@/lib/types";
+import { Media, MediaAttachedToType } from "@/lib/types";
 
 export default function MediaPage() {
   const [mediaList, setMediaList] = useState<Media[]>([]);
   const [loading, setLoading] = useState(true);
-  const [activeBucket, setActiveBucket] = useState<string>("all");
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingMedia, setEditingMedia] = useState<Partial<Media> | null>(null);
@@ -156,7 +155,7 @@ export default function MediaPage() {
             Media Manager
           </Heading>
           <Text color="admin.textMuted" fontSize="sm">
-            Browse uploaded images across storage buckets, upload new files, and link them to records.
+            {mediaList.length} {mediaList.length === 1 ? "item" : "items"} — upload new files and link them to records.
           </Text>
         </Box>
 
@@ -164,35 +163,6 @@ export default function MediaPage() {
           <Upload size={16} />
           Upload Media
         </Button>
-      </Flex>
-
-      {/* Bucket Filter Bar */}
-      <Flex gap={2} mb={6} wrap="wrap">
-        <Button
-          size="sm"
-          borderRadius="xl"
-          bg={activeBucket === "all" ? "brand.solid" : "admin.surface"}
-          border="1px solid"
-          borderColor={activeBucket === "all" ? "transparent" : "admin.border"}
-          color={activeBucket === "all" ? "white" : "admin.text"}
-          onClick={() => setActiveBucket("all")}
-        >
-          All Media ({mediaList.length})
-        </Button>
-        {Object.entries(STORAGE_BUCKETS).map(([key, bucket]) => (
-          <Button
-            key={key}
-            size="sm"
-            borderRadius="xl"
-            bg={activeBucket === bucket ? "brand.solid" : "admin.surface"}
-            border="1px solid"
-            borderColor={activeBucket === bucket ? "transparent" : "admin.border"}
-            color={activeBucket === bucket ? "white" : "admin.text"}
-            onClick={() => setActiveBucket(bucket)}
-          >
-            {bucket}
-          </Button>
-        ))}
       </Flex>
 
       {/* Media Grid */}

--- a/admin/app/(protected)/media/page.tsx
+++ b/admin/app/(protected)/media/page.tsx
@@ -7,18 +7,22 @@ import {
   Text,
   Flex,
   Button,
-  Badge,
   Image,
   Input,
   NativeSelect,
   VStack,
+  Menu,
+  Portal,
+  IconButton,
 } from "@chakra-ui/react";
-import { Upload, Link2, Pencil } from "lucide-react";
+import { Upload, MoreVertical, Pencil, Trash2 } from "lucide-react";
+import * as exifr from "exifr";
 import { ModalFormWrapper } from "@/components/ui/ModalFormWrapper";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { ImageUploader } from "@/components/ui/ImageUploader";
 import { PublishToggle } from "@/components/ui/PublishToggle";
 import { createClient } from "@/lib/supabase/client";
+import { relativeTime } from "@/lib/utils/relativeTime";
 import { Media, MediaAttachedToType } from "@/lib/types";
 
 export default function MediaPage() {
@@ -65,6 +69,7 @@ export default function MediaPage() {
       caption: "",
       attached_to_type: null,
       is_published: true,
+      captured_at: null,
     });
     setIsModalOpen(true);
   };
@@ -72,6 +77,23 @@ export default function MediaPage() {
   const openEditModal = (item: Media) => {
     setEditingMedia(item);
     setIsModalOpen(true);
+  };
+
+  // Reads the photo's own EXIF DateTimeOriginal, when present, so the card
+  // can show when it was actually taken rather than just when it was
+  // uploaded. Most re-encoded/screenshot/web-sourced images carry no EXIF
+  // at all -- that's expected, not an error, so this fails silently and
+  // just leaves captured_at unset (falls back to created_at for display).
+  const handleFileSelected = async (file: File) => {
+    try {
+      const exif = await exifr.parse(file, ["DateTimeOriginal"]);
+      const capturedAt = exif?.DateTimeOriginal as Date | undefined;
+      if (capturedAt instanceof Date && !isNaN(capturedAt.getTime())) {
+        setEditingMedia((prev) => ({ ...prev, captured_at: capturedAt.toISOString() }));
+      }
+    } catch {
+      // No EXIF data, or an unsupported format -- fine, just skip it.
+    }
   };
 
   const handleSaveMedia = async (e: React.FormEvent) => {
@@ -90,6 +112,7 @@ export default function MediaPage() {
             caption: editingMedia.caption || null,
             attached_to_type: (editingMedia.attached_to_type as MediaAttachedToType) || null,
             is_published: editingMedia.is_published ?? true,
+            captured_at: editingMedia.captured_at ?? null,
             updated_at: new Date().toISOString(),
           })
           .eq("id", editingMedia.id);
@@ -109,6 +132,7 @@ export default function MediaPage() {
           attached_to_id: null,
           sort_order: mediaList.length + 1,
           is_published: editingMedia.is_published ?? true,
+          captured_at: editingMedia.captured_at ?? null,
         };
 
         const { data, error } = await supabase.from("media").insert([newMedia]).select();
@@ -188,61 +212,57 @@ export default function MediaPage() {
                   {item.alt_text || "Untitled Media"}
                 </Text>
                 {item.caption && (
-                  <Text fontSize="xs" color="admin.textMuted" lineClamp={2} mb={3}>
+                  <Text fontSize="xs" color="admin.textMuted" mb={3}>
                     {item.caption}
                   </Text>
                 )}
 
-                <Flex align="center" gap={1.5} wrap="wrap" mb={3}>
-                  {item.attached_to_type ? (
-                    <Badge
-                      bg="#FBE9C9"
-                      color="#7A4D08"
-                      fontWeight="semibold"
-                      px={2}
-                      py={0.5}
-                      borderRadius="md"
-                      fontSize="xs"
-                      display="flex"
-                      alignItems="center"
-                      gap={1}
-                      w="fit-content"
-                    >
-                      <Link2 size={10} /> {item.attached_to_type}
-                    </Badge>
-                  ) : (
-                    <Badge bg="admin.bg" color="admin.text" fontWeight="semibold" border="1px solid" borderColor="admin.border" px={2} py={0.5} borderRadius="md" fontSize="xs">
-                      Unattached
-                    </Badge>
-                  )}
-                  <Badge
-                    bg={item.is_published ? "#E3F3E5" : "#FBE9C9"}
-                    color={item.is_published ? "#256633" : "#7A4D08"}
-                    fontWeight="semibold"
-                    px={2}
-                    py={0.5}
-                    borderRadius="md"
-                    fontSize="xs"
-                  >
-                    {item.is_published ? "Visible" : "Hidden"}
-                  </Badge>
-                </Flex>
-
                 <Flex justify="space-between" align="center" pt={3} borderTop="1px solid" borderColor="admin.border">
-                  <Button size="xs" variant="outline" borderColor="admin.border" color="admin.text" onClick={() => openEditModal(item)}>
-                    <Pencil size={12} /> Edit
-                  </Button>
-                  <Button
-                    size="xs"
-                    colorPalette="danger"
-                    variant="ghost"
-                    onClick={() => {
-                      setDeletingId(item.id);
-                      setIsDeleteOpen(true);
-                    }}
-                  >
-                    Delete
-                  </Button>
+                  <Flex align="center" gap={1.5}>
+                    <Box
+                      w="7px"
+                      h="7px"
+                      borderRadius="full"
+                      bg={item.is_published ? "#22C55E" : "#B8AC9E"}
+                      title={item.is_published ? "Visible" : "Hidden"}
+                      flexShrink={0}
+                    />
+                    <Text fontSize="xs" color="admin.textMuted">
+                      {relativeTime(item.captured_at || item.created_at)}
+                    </Text>
+                  </Flex>
+
+                  <Menu.Root>
+                    <Menu.Trigger asChild>
+                      <IconButton aria-label="More options" size="xs" variant="ghost" color="admin.textMuted" _hover={{ bg: "#F5F1EB", color: "admin.text" }}>
+                        <MoreVertical size={16} />
+                      </IconButton>
+                    </Menu.Trigger>
+                    <Portal>
+                      <Menu.Positioner>
+                        <Menu.Content bg="admin.surface" borderColor="admin.border" borderRadius="xl" boxShadow="0 12px 28px -8px rgba(26, 20, 16, 0.18)" minW="160px" py={1}>
+                          <Menu.Item value="edit" onClick={() => openEditModal(item)} color="admin.text" borderRadius="lg" _hover={{ bg: "#F5F1EB" }}>
+                            <Pencil size={14} />
+                            <Text ml={2}>Edit</Text>
+                          </Menu.Item>
+                          <Menu.Separator borderColor="admin.border" />
+                          <Menu.Item
+                            value="delete"
+                            onClick={() => {
+                              setDeletingId(item.id);
+                              setIsDeleteOpen(true);
+                            }}
+                            color="#B23610"
+                            borderRadius="lg"
+                            _hover={{ bg: "#FEF3EC" }}
+                          >
+                            <Trash2 size={14} />
+                            <Text ml={2}>Delete</Text>
+                          </Menu.Item>
+                        </Menu.Content>
+                      </Menu.Positioner>
+                    </Portal>
+                  </Menu.Root>
                 </Flex>
               </Box>
             </Box>
@@ -263,6 +283,7 @@ export default function MediaPage() {
           <ImageUploader
             value={editingMedia?.url}
             onChange={(url) => setEditingMedia((prev) => ({ ...prev, url }))}
+            onFileSelected={handleFileSelected}
             bucketName="media-gallery"
             label="Media File"
           />

--- a/admin/components/ui/ImageUploader.tsx
+++ b/admin/components/ui/ImageUploader.tsx
@@ -10,6 +10,10 @@ interface ImageUploaderProps {
   onChange: (url: string) => void;
   bucketName?: string;
   label?: string;
+  /** Fires with the raw File as soon as one is picked, before upload starts
+   *  -- lets a caller read client-side-only data (e.g. EXIF) that isn't
+   *  recoverable from the uploaded URL alone. */
+  onFileSelected?: (file: File) => void;
 }
 
 export function ImageUploader({
@@ -17,6 +21,7 @@ export function ImageUploader({
   onChange,
   bucketName = "media-gallery",
   label = "Upload Image",
+  onFileSelected,
 }: ImageUploaderProps) {
   const [uploading, setUploading] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -25,6 +30,7 @@ export function ImageUploader({
     const files = e.target.files;
     if (!files || files.length === 0) return;
     const file = files[0];
+    onFileSelected?.(file);
     await processUpload(file);
   };
 

--- a/admin/lib/types.ts
+++ b/admin/lib/types.ts
@@ -75,6 +75,10 @@ export interface Media {
   attached_to_id: string | null;
   sort_order: number;
   is_published: boolean;
+  /** From the photo's own EXIF DateTimeOriginal, when present -- null for
+   *  most re-encoded/screenshot/web-sourced images. Falls back to
+   *  created_at for display when absent. */
+  captured_at: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -14,6 +14,7 @@
         "@supabase/ssr": "^0.12.4",
         "@supabase/supabase-js": "^2.112.3",
         "@types/pg": "^8.21.0",
+        "exifr": "^7.1.3",
         "framer-motion": "^13.1.0",
         "lucide-react": "^1.33.0",
         "next": "16.3.1",
@@ -4760,6 +4761,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/exifr": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/exifr/-/exifr-7.1.3.tgz",
+      "integrity": "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/admin/package.json
+++ b/admin/package.json
@@ -15,6 +15,7 @@
     "@supabase/ssr": "^0.12.4",
     "@supabase/supabase-js": "^2.112.3",
     "@types/pg": "^8.21.0",
+    "exifr": "^7.1.3",
     "framer-motion": "^13.1.0",
     "lucide-react": "^1.33.0",
     "next": "16.3.1",

--- a/supabase/migrations/0014_media_captured_at.sql
+++ b/supabase/migrations/0014_media_captured_at.sql
@@ -1,0 +1,6 @@
+-- Photo capture date (from EXIF DateTimeOriginal, read client-side at
+-- upload time -- see ImageUploader's onFileSelected in the admin panel).
+-- Nullable: most re-encoded/screenshot/web-sourced images carry no EXIF at
+-- all, in which case the Media Manager falls back to created_at.
+alter table media
+  add column captured_at timestamptz;


### PR DESCRIPTION
## What changed

- Removed the bucket filter bar on the Media Manager — it updated its own
  highlight but never actually filtered the grid, and couldn't have worked
  even if wired up: `media` has no column recording which storage bucket a
  row's file lives in, and every upload from this page always goes to
  `media-gallery` regardless of which chip was selected.
- Redesigned media cards: swapped the "Attach to Record Type" badge for a
  timestamp (kept the field in the edit modal, just off the card face),
  replaced the separate Edit/Delete buttons with a single kebab (⋮) menu,
  added a small color dot for publish status (green = visible, gray =
  hidden), and removed the caption's line-clamp so it displays in full.
- Timestamp prefers the photo's real capture date, read from EXIF
  `DateTimeOriginal` client-side at upload time (new `onFileSelected` hook
  on `ImageUploader`, new `exifr` dependency), falling back to upload time
  when a photo carries no EXIF at all — verified against real photos in the
  repo, including one that actually had `DateTimeOriginal` set.

## Migration required
`supabase/migrations/0014_media_captured_at.sql` needs to be applied to the
live database (adds the nullable `media.captured_at` column) before this is
merged, same as `0012`/`0013` from the previous PR.

## Checklist

- [x] `npm run build` passes in `admin/` (if admin code changed)
- [x] No `.env.local` or real Supabase keys committed
- [x] If a table/column name changed: `supabase/migrations` and `admin/lib/types.ts` were both updated, and the team was notified
- [x] Tested manually in the browser
